### PR TITLE
fix to avoid api call to gitlab if apikey not present

### DIFF
--- a/src/main/java/com/capitalone/dashboard/collector/DefaultDeployClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultDeployClient.java
@@ -345,6 +345,7 @@ public class DefaultDeployClient implements DeployClient {
         ResponseEntity<String> response = null;
         try {
             log("Calling -> " + thisUrl.toUriString());
+            if(!apiKey.isEmpty())
             response = restOperations.exchange(thisUrl.toUriString(), HttpMethod.GET,
                     new HttpEntity<>(createHeaders(apiKey)), String.class);
 


### PR DESCRIPTION
This fix is added as we saw in some cases of using multiple api tokens i.e. say initially we started with 3 projectids-api key token combo and later we moved to only 1 projectid-apikey combo but the  projectIds are persisted into db in collector item but api key is not persisted .
In the above case , api call for some of the projectids are being made without the header api key so fixing it by making a call only when api key is present.